### PR TITLE
Add GitHub release script to build for Windows, Mac, and Linux 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,91 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            output_path: build/linux/x64/release/bundle
+            asset_name: chatmcp-linux-x64.tar.gz
+            build_target: linux
+          - os: macos-latest
+            output_path: build/macos/Build/Products/Release/chatmcp.app
+            asset_name: chatmcp-macos-x64.dmg
+            build_target: macos
+          - os: windows-latest
+            output_path: build/windows/x64/Runner/Release/chatmcp.exe
+            asset_name: chatmcp-windows-x64.exe
+            build_target: windows
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.27.0'
+      
+      - name: Create empty .env file
+        run: touch .env
+
+      - name: Install Linux Dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build libgtk-3-dev
+      
+      - name: Install dependencies
+        run: flutter pub get
+      
+      - name: Build ${{ matrix.build_target }}
+        run: flutter build ${{ matrix.build_target }} --release
+      
+      - name: Package Linux App
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cd build/linux/x64/release/bundle
+          tar -czf "${GITHUB_WORKSPACE}/${{ matrix.asset_name }}" *
+      
+      - name: Package macOS App
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install create-dmg
+          create-dmg \
+            --volname "ChatMcp" \
+            --window-pos 200 120 \
+            --window-size 800 400 \
+            --icon-size 100 \
+            --icon "chatmcp.app" 200 190 \
+            --hide-extension "chatmcp.app" \
+            --app-drop-link 600 185 \
+            "${{ matrix.asset_name }}" \
+            "${{ matrix.output_path }}"
+      
+      - name: Copy Windows Executable
+        if: matrix.os == 'windows-latest'
+        run: |
+          Copy-Item -Path "build/windows/x64/Runner/Release/chatmcp.exe" -Destination "${{ matrix.asset_name }}"
+      
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chatmcp-${{ matrix.build_target }}
+          path: ${{ matrix.asset_name }}
+      
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ matrix.asset_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,71 @@
+# Release Instructions
+
+This document outlines the process for creating new releases of ChatMcp.
+
+## Release Process
+
+1. **Prepare for Release**
+   - Ensure all desired changes are merged into the main branch
+   - Update version numbers in relevant files
+   - Update changelog if applicable
+
+2. **Create and Push a Release Tag**
+   ```bash
+   # Ensure you're on the main branch
+   git checkout main
+   git pull origin main
+
+   # Create a new tag
+   git tag v1.0.0  # Replace with your version number
+
+   # Push the tag
+   git push origin v1.0.0
+   ```
+
+3. **GitHub Actions Automation**
+   The tag push will automatically trigger the release workflow which:
+   - Builds the application for all platforms (Linux, macOS, and Windows)
+   - Creates platform-specific packages:
+     - Linux: `chatmcp-linux-x64.tar.gz`
+     - macOS: `chatmcp-macos-x64.dmg`
+     - Windows: `chatmcp-windows-x64.zip`
+   - Creates a GitHub release with these packages
+
+4. **Monitor the Build**
+   - Go to the GitHub Actions tab in the repository
+   - Monitor the "Build and Release" workflow
+   - Ensure all platforms build successfully
+
+5. **Verify the Release**
+   After the workflow completes:
+   - Go to the Releases page on GitHub
+   - Verify that all artifacts are present
+   - Check that the packages can be downloaded
+   - Test the packages on respective platforms if possible
+
+## Manual Release (if needed)
+
+If you need to trigger a build manually:
+1. Go to the GitHub Actions tab
+2. Select the "Build and Release" workflow
+3. Click "Run workflow"
+4. Select the branch to build from
+5. Click "Run workflow"
+
+## Troubleshooting
+
+If the release build fails:
+1. Check the GitHub Actions logs for error messages
+2. Common issues:
+   - Insufficient permissions (needs `GITHUB_TOKEN`)
+   - Network connectivity issues
+   - Platform-specific build dependencies missing
+
+## Version Numbering
+
+We follow [Semantic Versioning](https://semver.org/):
+- MAJOR version for incompatible API changes
+- MINOR version for backwards-compatible functionality additions
+- PATCH version for backwards-compatible bug fixes
+
+Example: v1.0.0, v1.1.0, v1.1.1 

--- a/lib/utils/process.dart
+++ b/lib/utils/process.dart
@@ -66,13 +66,25 @@ Future<bool> isCommandAvailable(String command) async {
   }
 }
 
+Future<Map<String, String>> getDefaultEnv() async {
+  final Map<String, String> env = Map.of(Platform.environment);
+  env['PATH'] = await getDefaultPath();
+  
+  if (Platform.isWindows) {
+    env['PYTHONIOENCODING'] = 'utf-8';
+    env['PYTHONLEGACYWINDOWSSTDIO'] = 'utf-8';
+  }
+  
+  return env;
+}
+
 Future<Process> startProcess(
   String command,
   List<String> args,
   Map<String, String> environment,
 ) async {
-  final Map<String, String> env = Map.of(environment);
-  env['PATH'] = await getDefaultPath();
+  final Map<String, String> env = await getDefaultEnv();
+  env.addAll(environment); // Add user provided environment variables
 
   return Process.start(
     command,


### PR DESCRIPTION
This adds GitHub action script that build the flutter app and create new release when we push new git tag.

You can see an example release in my fork here https://github.com/adhikasp/chatmcp/releases

```
git tag v1.0.0
git push origin v1.0.0

```

Also it fix MCP server run with uvx in Windows because of some console charmap incompatibilities by configuring default env var.

## Windows build

![image](https://github.com/user-attachments/assets/c05fa8f8-cc8e-46f6-ad87-7c6c991b1a78)

## Mac build

![image](https://github.com/user-attachments/assets/659ca1f2-a56b-4f27-a9c7-39c542ff9d74)


## Linux build

(n/a, I don't have Linux machine)