### PR TITLE
filter out deployments use o1-mini and o1-preview models

### DIFF
--- a/lib/llm/foundry_client.dart
+++ b/lib/llm/foundry_client.dart
@@ -178,7 +178,9 @@ class FoundryClient extends BaseLLMClient {
       }
 
       final data = jsonDecode(response.body);
-      final models = (data['data'] as List).where((m) => m['status'] == 'succeeded').map((m) => m['id'].toString()).toList();
+
+      // Filter out models o1-mini and o1-preview, because of unsupported system message
+      final models = (data['data'] as List).where((m) => m['status'] == 'succeeded' && m['model'] != 'o1-mini' && m['model'] != 'o1-preview').map((m) => m['id'].toString()).toList();
 
       return models;
     } catch (e, trace) {


### PR DESCRIPTION
filter out deployments use o1-mini and o1-preview models, because of these models are unsupported system / developer message role. For more details please check [here](https://community.openai.com/t/developer-role-not-accepted-for-o1-o1-mini-o3-mini/1110750)

It is a general issue for all OpenAI LLMs.