### PR TITLE
fix: Rendering and Life-cycle Errors in Chat Message Streaming, Issue…

### DIFF
--- a/lib/page/layout/chat_page/chat_message.dart
+++ b/lib/page/layout/chat_page/chat_message.dart
@@ -13,7 +13,11 @@ import 'chat_message_action.dart';
 import 'package:chatmcp/generated/app_localizations.dart';
 import 'chat_loading.dart';
 
-// 文件附件组件
+/// Document attachment component is used to display the file attachment in the chat message.
+///
+/// - [path] The path of the file
+/// - [name] The name of the file
+/// - [fileType] The type of the file
 class FileAttachment extends StatelessWidget {
   final String path;
   final String name;
@@ -99,7 +103,10 @@ class FileAttachment extends StatelessWidget {
   }
 }
 
-// 移动端长按菜单
+/// Message long press menu is used to display the long press menu in the chat message.
+///
+/// - [message] The message
+/// - [onRetry] The function to retry the message
 class MessageLongPressMenu extends StatelessWidget {
   final ChatMessage message;
   final Function(ChatMessage) onRetry;
@@ -146,6 +153,11 @@ class MessageLongPressMenu extends StatelessWidget {
   }
 }
 
+/// Chat UI message is used to display the chat message in the chat page.
+///
+/// - [messages] The list of messages
+/// - [onRetry] The function to retry the message
+/// - [onSwitch] The function to switch the message
 class ChatUIMessage extends StatelessWidget {
   final List<ChatMessage> messages;
   final Function(ChatMessage) onRetry;
@@ -181,6 +193,7 @@ class ChatUIMessage extends StatelessWidget {
 
     if (filteredMessages.length == 1) {
       return ChatMessageContent(
+        key: ValueKey(filteredMessages[0].messageId),
         message: filteredMessages[0],
         onRetry: onRetry,
         position: BubblePosition.single,
@@ -202,6 +215,7 @@ class ChatUIMessage extends StatelessWidget {
               bottom: index == filteredMessages.length - 1 ? 0 : 1,
             ),
             child: ChatMessageContent(
+              key: ValueKey(filteredMessages[index].messageId),
               message: filteredMessages[index],
               onRetry: onRetry,
               position: _getMessagePosition(index, filteredMessages.length),
@@ -269,6 +283,12 @@ class ChatUIMessage extends StatelessWidget {
   }
 }
 
+/// Chat message content is used to display the chat message content in the chat message.
+///
+/// - [message] The message
+/// - [onRetry] The function to retry the message
+/// - [position] The position of the message
+/// - [useTransparentBackground] Whether to use transparent background
 class ChatMessageContent extends StatelessWidget {
   final ChatMessage message;
   final Function(ChatMessage) onRetry;
@@ -308,11 +328,12 @@ class ChatMessageContent extends StatelessWidget {
         ),
       );
     }
-
+    final bubbleKey = message.messageId;
     if ((message.role == MessageRole.user ||
             message.role == MessageRole.assistant) &&
         message.content != null) {
       messages.add(MessageBubble(
+        key: ValueKey('${bubbleKey}_content'),
         message: message,
         position: position,
         useTransparentBackground: useTransparentBackground,
@@ -321,6 +342,7 @@ class ChatMessageContent extends StatelessWidget {
 
     if (message.toolCalls != null && message.toolCalls!.isNotEmpty) {
       messages.add(MessageBubble(
+        key: ValueKey('${bubbleKey}_tool_calls'),
         message: message,
         position: position,
         useTransparentBackground: useTransparentBackground,
@@ -329,6 +351,7 @@ class ChatMessageContent extends StatelessWidget {
 
     if (message.role == MessageRole.tool && message.toolCallId != null) {
       messages.add(MessageBubble(
+        key: ValueKey('${bubbleKey}_tool_result'),
         message: message,
         position: position,
         useTransparentBackground: useTransparentBackground,
@@ -362,6 +385,12 @@ class ChatMessageContent extends StatelessWidget {
   }
 }
 
+/// Bubble position is used to determine the position of the bubble in the chat message.
+///
+/// - [first] The first bubble
+/// - [middle] The middle bubble
+/// - [last] The last bubble
+/// - [single] The single bubble
 enum BubblePosition {
   first,
   middle,
@@ -369,6 +398,11 @@ enum BubblePosition {
   single,
 }
 
+/// Message bubble is used to display the message bubble in the chat message.
+///
+/// - [message] The message
+/// - [position] The position of the message
+/// - [useTransparentBackground] Whether to use transparent background
 class MessageBubble extends StatelessWidget {
   final ChatMessage message;
   final BubblePosition position;
@@ -468,6 +502,9 @@ class MessageBubble extends StatelessWidget {
   }
 }
 
+/// Tool call widget is used to display the tool call in the chat message.
+///
+/// - [message] The message
 class ToolCallWidget extends StatelessWidget {
   final ChatMessage message;
 
@@ -509,6 +546,9 @@ class ToolCallWidget extends StatelessWidget {
   }
 }
 
+/// Tool result widget is used to display the tool result in the chat message.
+///
+/// - [message] The message
 class ToolResultWidget extends StatelessWidget {
   final ChatMessage message;
 
@@ -560,6 +600,9 @@ class ToolResultWidget extends StatelessWidget {
   }
 }
 
+/// Chat avatar is used to display the chat avatar in the chat message.
+///
+/// - [isUser] Whether the avatar is for the user
 class ChatAvatar extends StatelessWidget {
   final bool isUser;
 

--- a/lib/page/layout/chat_page/chat_message_list.dart
+++ b/lib/page/layout/chat_page/chat_message_list.dart
@@ -5,7 +5,11 @@ import 'package:flutter/rendering.dart';
 import 'chat_message.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 
-
+/// Message list is used to display the list of messages in the chat page.
+///
+/// - [messages] The list of messages to display.
+/// - [onRetry] The function to retry the message.
+/// - [onSwitch] The function to switch the message to the another message.
 class MessageList extends StatefulWidget {
   final List<ChatMessage> messages;
   final Function(ChatMessage) onRetry;
@@ -34,7 +38,7 @@ class _MessageListState extends State<MessageList> {
   bool _isScrolledToBottom({double threshold = 1.0}) {
     if (!_scrollController.hasClients) return true;
     final currentScroll = _scrollController.offset;
-    // 允许1像素的误差
+    // Allow 1 pixel of error
     return (endScroll - currentScroll).abs() <= threshold;
   }
 
@@ -112,7 +116,7 @@ class _MessageListState extends State<MessageList> {
           _scrollToBottom();
         }
 
-        // 将消息分组
+        // Group messages
         List<List<ChatMessage>> groupedMessages = [];
         List<ChatMessage> currentGroup = [];
 
@@ -141,11 +145,12 @@ class _MessageListState extends State<MessageList> {
               controller: _scrollController,
               padding: const EdgeInsets.all(16.0),
               itemCount: groupedMessages.length,
-              // physics: const ClampingScrollPhysics(), // 禁用弹性效果
+              // physics: const ClampingScrollPhysics(), // Disable elastic effect
               itemBuilder: (context, index) {
                 final group = groupedMessages[index];
 
                 return ChatUIMessage(
+                  key: ValueKey(group.first.messageId),
                   messages: group,
                   onRetry: widget.onRetry,
                   onSwitch: widget.onSwitch,

--- a/lib/widgets/markdown/markit_widget.dart
+++ b/lib/widgets/markdown/markit_widget.dart
@@ -39,26 +39,34 @@ This image is a math problem, involving the calculation of the cost of anti-slip
   }
 }
 
-class Markit extends StatelessWidget {
+class Markit extends StatefulWidget {
   final String data;
   final TextStyle? textStyle;
 
   const Markit({super.key, required this.data, this.textStyle});
 
   @override
-  Widget build(BuildContext context) => ConstrainedBox(
-        constraints: const BoxConstraints(
-          minHeight: 0,
-          maxHeight: double.infinity,
-        ),
-        child: buildMarkdown(context),
-      );
+  State<Markit> createState() => _MarkitState();
+}
 
-  Widget buildMarkdown(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final config =
-        isDark ? MarkdownConfig.darkConfig : MarkdownConfig.defaultConfig;
-    return SingleChildScrollView(
+class _MarkitState extends State<Markit> {
+  String _cachedData = '';
+  Widget? _cachedMarkdown;
+  Brightness? _cachedBrightness;
+
+  @override
+  Widget build(BuildContext context) {
+
+    final currentBrightness = Theme.of(context).brightness;
+    if (widget.data != _cachedData || _cachedMarkdown == null ||  _cachedBrightness != currentBrightness) {
+
+    _cachedData = widget.data;
+    _cachedBrightness = currentBrightness;
+
+    final isDark = currentBrightness == Brightness.dark;
+    final textStyle= widget.textStyle;
+    final data = _cachedData;
+    _cachedMarkdown = SingleChildScrollView(
       child: MarkdownBlock(
         data: data,
         config: MarkdownConfig(
@@ -125,5 +133,11 @@ class Markit extends StatelessWidget {
         ),
       ),
     );
+    }
+    return ConstrainedBox(
+        constraints: const BoxConstraints(
+          minHeight: 0,
+          maxHeight: double.infinity,),
+        child: _cachedMarkdown ?? const SizedBox());
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   cli_config:
     dependency: transitive
     description:
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "4b8701e48a58f7712492c9b1f7ba0bb9d525644dd66d023b62e1fc8cdb560c8a"
+      sha256: aa07dbe5f2294c827b7edb9a87bba44a9c15a3cc81bc8da2ca19b37322d30080
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.0"
+    version: "1.14.1"
   cross_file:
     dependency: transitive
     description:
@@ -301,10 +301,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: "77f8e81d22d2a07d0dee2c62e1dda71dc1da73bf43bb2d45af09727406167964"
+      sha256: ef9908739bdd9c476353d6adff72e88fd00c625f5b959ae23f7567bd5137db0a
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.9"
+    version: "10.2.0"
   fixnum:
     dependency: transitive
     description:
@@ -466,10 +466,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_launcher_icons
-      sha256: bfa04787c85d80ecb3f8777bde5fc10c3de809240c48fa061a2c2bf15ea5211c
+      sha256: "10f13781741a2e3972126fae08393d3c4e01fa4cd7473326b94b72cf594195e7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.3"
+    version: "0.14.4"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -503,10 +503,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_popup
-      sha256: "63cbae63fb15f81be1b533cc53306d3835305e314e8ce99c62b98d45ab685261"
+      sha256: "08e554be1173f4e7bb5eda2ae2e5addd565873026a3ac9b64c38ea86dfd4dc9d"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.7"
+    version: "3.3.9"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -1182,10 +1182,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqflite_common_ffi
-      sha256: "1f3ef3888d3bfbb47785cc1dda0dc7dd7ebd8c1955d32a9e8e9dae1e38d1c4c1"
+      sha256: "9faa2fedc5385ef238ce772589f7718c24cdddd27419b609bb9c6f703ea27988"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.5"
+    version: "2.3.6"
   sqflite_darwin:
     dependency: transitive
     description:
@@ -1382,10 +1382,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "44cc7104ff32563122a929e4620cf3efd584194eec6d1d913eb5ba593dbcf6de"
+      sha256: a4f059dc26fc8295b5921376600a194c4ec7d55e72f2fe4c7d2831e103d461e6
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.18"
+    version: "1.1.19"
   vector_graphics_codec:
     dependency: transitive
     description:
@@ -1430,10 +1430,10 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: "69da27e49efa56a15f8afe8f4438c4ec02eff0a117df1b22ea4aad194fe1c104"
+      sha256: "0b7fd4a0bbc4b92641dbf20adfd7e3fd1398fe17102d94b674234563e110088a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   web:
     dependency: transitive
     description:
@@ -1470,10 +1470,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "329edf97fdd893e0f1e3b9e88d6a0e627128cc17cc316a8d67fda8f1451178ba"
+      sha256: "66814138c3562338d05613a6e368ed8cfb237ad6d64a9e9334be3f309acfca03"
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.0"
+    version: "5.14.0"
   window_manager:
     dependency: "direct main"
     description:


### PR DESCRIPTION
… link: https://github.com/daodao97/chatmcp/issues/140

This addresses a critical bug that caused two distinct errors in the chat interface, primarily when rendering streaming markdown content with complex elements like code blocks.
1. The !debugNeedsLayout Error
Problem: When receiving a streaming response from the LLM, especially one containing markdown with code blocks, the application would frequently crash with a !debugNeedsLayout assertion error. This indicated that a widget was being painted or processed while its layout was still being calculated, a common issue with frequent and inefficient state updates on complex widgets.
Root Cause: The Markit widget, which renders markdown, was a StatelessWidget that rebuilt the entire MarkdownBlock on every single data chunk received from the stream. This caused significant performance bottlenecks and race conditions in Flutter's rendering pipeline.
2. The Markit widget had been converted to a StatefulWidget, but its state initialization logic in initState improperly accessed Theme.of(context). According to Flutter's widget lifecycle, context-dependent objects like themes cannot be accessed in initState because the widget has not yet been fully mounted in the tree.
Solution Implemented:
A two-part solution was implemented to resolve both issues and improve overall performance and stability.
3. Optimized Widget Reconciliation and State Management:
Unique Keys: Added unique ValueKeys to MessageBubble widgets within ChatMessageContent. This ensures Flutter's reconciliation algorithm can correctly identify and update widgets during rebuilds, preventing unnecessary tree mutations.
Lifecycle-Aware Caching in Markit Widget:
The _MarkitState was refactored to remove all context-dependent logic from initState.
The markdown rendering logic now resides entirely within the build method.
The rendered MarkdownBlock widget is cached in a state variable (_cachedMarkdown).
This cache is only invalidated and rebuilt if:
The input data string changes.
The Theme.of(context).brightness changes (to support dark/light mode switching).
This approach ensures that expensive markdown parsing and rendering only occur when absolutely necessary, respecting the widget lifecycle and eliminating both the layout and dependency errors.
These changes have made the chat interface more robust, performant, and free of rendering-related crashes, especially during real-time message streaming.