### PR TITLE
feat: Add Claude Code client implementation and integrate into LLMFactory

### DIFF
--- a/lib/llm/claude_code_client.dart
+++ b/lib/llm/claude_code_client.dart
@@ -1,0 +1,230 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+
+import 'base_llm_client.dart';
+import 'model.dart';
+
+/// Claude Code client backed by the `claude` CLI.
+///
+/// This client shells out to the Claude Code SDK CLI, so it works without
+/// directly using Anthropic HTTP APIs. It expects the `claude` binary to be
+/// available on PATH (or via a configured absolute path), and that the user
+/// has already authenticated per Claude Code SDK docs.
+///
+/// Non-goals:
+/// - Tool calling is not wired, as Claude Code has its own tool system
+///   (Read/Write/Bash). We ignore `tools` in requests.
+class ClaudeCodeClient extends BaseLLMClient {
+  /// Path or name of the Claude Code CLI executable. Defaults to `claude`.
+  final String executable;
+
+  ClaudeCodeClient({String? executablePath}) : executable = (executablePath == null || executablePath.isEmpty) ? 'claude' : executablePath;
+
+  @override
+  Future<LLMResponse> chatCompletion(CompletionRequest request) async {
+    final prompt = _buildPromptFromMessages(request.messages);
+
+    // Use JSON output for reliable parsing
+    final args = <String>['-p', prompt, '--output-format', 'json'];
+
+    try {
+      final result = await Process.run(executable, args, runInShell: true);
+
+      if (result.exitCode != 0) {
+        throw Exception(result.stderr is String && (result.stderr as String).isNotEmpty ? result.stderr : 'Claude Code CLI exited with ${result.exitCode}');
+      }
+
+      final output = result.stdout is String ? result.stdout as String : utf8.decode((result.stdout as List<int>));
+      final content = _parseClaudeCodeJsonOutput(output);
+      return LLMResponse(content: content);
+    } catch (e) {
+      // Surface a structured error via BaseLLMClient.handleError contract
+      throw await handleError(
+        e,
+        'Claude Code',
+        executable,
+        jsonEncode({'args': args}),
+      );
+    }
+  }
+
+  @override
+  Stream<LLMResponse> chatStreamCompletion(CompletionRequest request) async* {
+    final prompt = _buildPromptFromMessages(request.messages);
+
+    // Stream JSON lines so we can emit partial updates when possible.
+    final args = <String>['-p', prompt, '--output-format', 'stream-json'];
+
+    Process? process;
+    try {
+      process = await Process.start(executable, args, runInShell: true);
+
+      final stdoutLines = process.stdout.transform(utf8.decoder).transform(const LineSplitter());
+      final stderrBuffer = StringBuffer();
+
+      // Drain stderr to help debugging on failure
+      unawaited(process.stderr.transform(utf8.decoder).forEach(stderrBuffer.write));
+
+      String aggregated = '';
+
+      await for (final line in stdoutLines) {
+        // Expecting JSONL objects, one per line
+        try {
+          final obj = jsonDecode(line);
+          final type = obj['type'];
+          if (type == 'assistant') {
+            final contentPiece = _extractTextFromAssistantMessage(obj['message']);
+            if (contentPiece.isNotEmpty) {
+              aggregated += contentPiece;
+              yield LLMResponse(content: contentPiece);
+            }
+          } else if (type == 'result') {
+            // Final result line; emit any missing content if stream lacked assistant pieces
+            final resultText = (obj['result'] ?? '').toString();
+            if (aggregated.isEmpty && resultText.isNotEmpty) {
+              yield LLMResponse(content: resultText);
+            }
+          }
+        } catch (_) {
+          // If a line isn't valid JSON, ignore it; CLI may print logs in verbose modes
+          continue;
+        }
+      }
+
+      final exitCode = await process.exitCode;
+      if (exitCode != 0) {
+        throw Exception(stderrBuffer.isNotEmpty ? stderrBuffer.toString() : 'Claude Code CLI exited with $exitCode');
+      }
+    } catch (e) {
+      throw await handleError(
+        e,
+        'Claude Code',
+        executable,
+        jsonEncode({'args': args}),
+      );
+    } finally {
+      // Ensure process is killed if still alive
+      if (process != null) {
+        try {
+          process.kill(ProcessSignal.sigterm);
+        } catch (_) {}
+      }
+    }
+  }
+
+  @override
+  Future<List<String>> models() async {
+    // Claude Code CLI does not expose a model listing endpoint.
+    // Return a common set; users can customize in settings.
+    return <String>[
+      'claude-3-7-sonnet',
+      'claude-3-opus',
+      'claude-3-5-sonnet',
+      'claude-3-5-haiku',
+    ];
+  }
+
+  String _buildPromptFromMessages(List<ChatMessage> messages) {
+    // Keep recent context small to avoid overly long shell args.
+    const int maxMessages = 12;
+    final recent = messages.length <= maxMessages ? messages : messages.sublist(messages.length - maxMessages);
+
+    final buffer = StringBuffer();
+    for (final m in recent) {
+      final content = (m.content ?? '').trim();
+      if (content.isEmpty) continue;
+      switch (m.role) {
+        case MessageRole.system:
+          buffer.writeln('System: $content');
+          break;
+        case MessageRole.user:
+          buffer.writeln('User: $content');
+          break;
+        case MessageRole.assistant:
+          buffer.writeln('Assistant: $content');
+          break;
+        default:
+          // Ignore tool/function/error/loading in prompt for Claude Code
+          break;
+      }
+    }
+    return buffer.toString().trim();
+  }
+
+  /// Parse JSON output from `claude -p --output-format json`.
+  /// The CLI typically prints a single JSON object. If multiple JSONL lines
+  /// are present, prefer the final `result` type; otherwise accumulate
+  /// assistant messages.
+  String _parseClaudeCodeJsonOutput(String output) {
+    output = output.trim();
+    if (output.isEmpty) return '';
+
+    // Try strict JSON first
+    try {
+      final obj = jsonDecode(output);
+      final type = obj is Map<String, dynamic> ? obj['type'] : null;
+      if (type == 'result') {
+        return (obj['result'] ?? '').toString();
+      }
+      if (type == 'assistant') {
+        return _extractTextFromAssistantMessage(obj['message']);
+      }
+      // Some versions might output a flat object with `result`
+      if (obj is Map<String, dynamic> && obj.containsKey('result')) {
+        return (obj['result'] ?? '').toString();
+      }
+    } catch (_) {
+      // Fall through to JSONL mode
+    }
+
+    // Fallback: parse line-by-line as JSONL
+    String aggregated = '';
+    for (final line in const LineSplitter().convert(output)) {
+      final trimmed = line.trim();
+      if (trimmed.isEmpty) continue;
+      try {
+        final obj = jsonDecode(trimmed);
+        final type = obj['type'];
+        if (type == 'assistant') {
+          aggregated += _extractTextFromAssistantMessage(obj['message']);
+        } else if (type == 'result') {
+          if (aggregated.isEmpty) {
+            aggregated = (obj['result'] ?? '').toString();
+          }
+        }
+      } catch (_) {
+        continue;
+      }
+    }
+    return aggregated;
+  }
+
+  /// Extract plain text from an Anthropic SDK `Message` object
+  /// produced by Claude Code CLI JSON messages.
+  String _extractTextFromAssistantMessage(dynamic messageObj) {
+    if (messageObj == null) return '';
+    try {
+      final content = messageObj['content'];
+      if (content is List) {
+        final texts = <String>[];
+        for (final part in content) {
+          if (part is Map<String, dynamic>) {
+            final type = part['type'];
+            if (type == 'text' && part['text'] is String) {
+              texts.add(part['text'] as String);
+            }
+          }
+        }
+        return texts.join('');
+      }
+    } catch (e) {
+      Logger.root.fine('Failed to parse assistant message content: $e');
+    }
+    return '';
+  }
+}
+
+

--- a/lib/llm/llm_factory.dart
+++ b/lib/llm/llm_factory.dart
@@ -5,12 +5,13 @@ import 'base_llm_client.dart';
 import 'ollama_client.dart';
 import 'gemini_client.dart';
 import 'foundry_client.dart';
+import 'claude_code_client.dart';
 import 'package:chatmcp/provider/provider_manager.dart';
 import 'package:chatmcp/provider/settings_provider.dart';
 import 'package:logging/logging.dart';
 import 'model.dart' as llm_model;
 
-enum LLMProvider { openai, claude, ollama, deepseek, gemini, foundry }
+enum LLMProvider { openai, claude, ollama, deepseek, gemini, foundry, claudeCode }
 
 class LLMFactory {
   static BaseLLMClient create(LLMProvider provider, {required String apiKey, required String baseUrl, String? apiVersion}) {
@@ -19,6 +20,8 @@ class LLMFactory {
         return OpenAIClient(apiKey: apiKey, baseUrl: baseUrl);
       case LLMProvider.claude:
         return ClaudeClient(apiKey: apiKey, baseUrl: baseUrl);
+      case LLMProvider.claudeCode:
+        return ClaudeCodeClient();
       case LLMProvider.deepseek:
         return DeepSeekClient(apiKey: apiKey, baseUrl: baseUrl);
       case LLMProvider.ollama:
@@ -41,6 +44,7 @@ class LLMFactoryHelper {
   static final Map<String, LLMProvider> providerMap = {
     "openai": LLMProvider.openai,
     "claude": LLMProvider.claude,
+    "claude-code": LLMProvider.claudeCode,
     "deepseek": LLMProvider.deepseek,
     "ollama": LLMProvider.ollama,
     "gemini": LLMProvider.gemini,
@@ -62,7 +66,7 @@ class LLMFactoryHelper {
     try {
       final setting = ProviderManager.settingsProvider.apiSettings.firstWhere((element) => element.providerId == currentModel.providerId);
 
-      // 检查提供商是否启用（null 表示启用，只有 false 为禁用）
+      // Check if the provider is enabled (null means enabled, only false means disabled)
       final isEnabled = setting.enable ?? true;
       if (!isEnabled) {
         throw Exception('Provider ${currentModel.providerId} is disabled');

--- a/lib/provider/settings_provider.dart
+++ b/lib/provider/settings_provider.dart
@@ -222,6 +222,26 @@ final List<LLMProviderSetting> defaultApiSettings = [
   ),
   LLMProviderSetting(
     apiKey: '',
+    apiEndpoint: '', // Not used by CLI mode
+    apiStyle: 'claude-code',
+    providerId: 'claude-code',
+    providerName: 'Claude Code',
+    icon: 'claude',
+    custom: false,
+    link: 'https://docs.anthropic.com/en/docs/claude-code/sdk',
+    models: [
+      'claude-3-7-sonnet',
+      'claude-3-opus',
+      'claude-3-5-sonnet',
+      'claude-3-5-haiku',
+    ],
+    enabledModels: [
+      'claude-3-7-sonnet',
+      'claude-3-5-sonnet',
+    ],
+  ),
+  LLMProviderSetting(
+    apiKey: '',
     apiEndpoint: 'https://api.deepseek.com',
     apiStyle: 'deepseek',
     providerId: 'deepseek',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "01949bf52ad33f0e0f74f881fbaac4f348c556531951d92c8d16f1262aa19ff8"
+      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
       url: "https://pub.dev"
     source: hosted
-    version: "7.5.4"
+    version: "7.7.1"
   archive:
     dependency: transitive
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7"
+      sha256: "7d95cbbb1526ab5ae977df9b4cc660963b9b27f6d1075c0b34653868911385e4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "3.0.0"
   build_config:
     dependency: transitive
     description:
@@ -85,26 +85,26 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62
+      sha256: "38c9c339333a09b090a638849a4c56e70a404c6bdd3b511493addfbc113b60c2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "3.0.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53"
+      sha256: b971d4a1c789eba7be3e6fe6ce5e5b50fd3719e3cb485b3fad6d04358304351d
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "2.6.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792"
+      sha256: c04e612ca801cd0928ccdb891c263a2b1391cb27940a5ea5afcf9ba894de5d62
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.2"
+    version: "9.2.0"
   built_collection:
     dependency: transitive
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "082001b5c3dc495d4a42f1d5789990505df20d8547d42507c29050af6933ee27"
+      sha256: ba95c961bafcd8686d1cf63be864eb59447e795e124d98d6a27d91fcd13602fb
       url: "https://pub.dev"
     source: hosted
-    version: "8.10.1"
+    version: "8.11.1"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: aa07dbe5f2294c827b7edb9a87bba44a9c15a3cc81bc8da2ca19b37322d30080
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.1"
+    version: "1.15.0"
   cross_file:
     dependency: transitive
     description:
@@ -253,10 +253,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "5b236382b47ee411741447c1f1e111459c941ea1b3f2b540dde54c210a3662af"
+      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   dbus:
     dependency: transitive
     description:
@@ -277,10 +277,10 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
+      sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.0+1"
+    version: "5.9.0"
   dio_web_adapter:
     dependency: transitive
     description:
@@ -333,10 +333,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: ef9908739bdd9c476353d6adff72e88fd00c625f5b959ae23f7567bd5137db0a
+      sha256: "97a943524074a1e8e858aa154d09e38a4168a9ad765d6cac66606fd906b86875"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.0"
+    version: "10.2.2"
   fixnum:
     dependency: transitive
     description:
@@ -527,10 +527,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: f948e346c12f8d5480d2825e03de228d0eb8c3a737e4cdaa122267b89c022b5e
+      sha256: "6382ce712ff69b0f719640ce957559dde459e55ecd433c767e06d139ddf16cab"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.28"
+    version: "2.0.29"
   flutter_popup:
     dependency: "direct main"
     description:
@@ -617,10 +617,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   http_methods:
     dependency: transitive
     description:
@@ -689,10 +689,10 @@ packages:
     dependency: "direct main"
     description:
       name: json_serializable
-      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
+      sha256: ce2cf974ccdee13be2a510832d7fba0b94b364e0b0395dee42abaa51b855be27
       url: "https://pub.dev"
     source: hosted
-    version: "6.9.5"
+    version: "6.10.0"
   keyboard_dismisser:
     dependency: "direct main"
     description:
@@ -801,10 +801,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: "4546eac99e8967ea91bae633d2ca7698181d008e95fa4627330cf903d573277a"
+      sha256: "2314cbe9165bcd16106513df9cf3c3224713087f09723b128928dc11a4379f99"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.6"
+    version: "5.5.0"
   nested:
     dependency: transitive
     description:
@@ -1121,10 +1121,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "20cbd561f743a342c76c151d6ddb93a9ce6005751e7aa458baad3858bfbfb6ac"
+      sha256: "5bcf0772a761b04f8c6bf814721713de6f3e5d9d89caf8d3fe031b02a342379e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.10"
+    version: "2.4.11"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1222,18 +1222,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      sha256: fc787b1f89ceac9580c3616f899c9a447413cbdac1df071302127764c023a134
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
+      sha256: "4f81479fe5194a622cdd1713fe1ecb683a6e6c85cd8cec8e2e35ee5ab3fdf2a1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.5"
+    version: "1.3.6"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -1286,10 +1286,10 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "84731e8bfd8303a3389903e01fb2141b6e59b5973cacbb0929021df08dddbe8b"
+      sha256: "6ef422a4525ecc601db6c0a2233ff448c731307906e92cabc9ba292afaae16a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.5"
+    version: "2.5.6"
   sqflite_common_ffi:
     dependency: "direct main"
     description:
@@ -1302,10 +1302,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqflite_common_ffi_web
-      sha256: "983cf7b33b16e6bc086c8e09f6a1fae69d34cdb167d7acaf64cbd3515942d4e6"
+      sha256: "33495e9172c958d907c48fd43fbea0b9c0a2ec2e36a548ebd07672fde61b6497"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1+1"
   sqflite_darwin:
     dependency: transitive
     description:
@@ -1326,10 +1326,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: c0503c69b44d5714e6abbf4c1f51a3c3cc42b75ce785f44404765e4635481d38
+      sha256: f393d92c71bdcc118d6203d07c991b9be0f84b1a6f89dd4f7eed348131329924
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.6"
+    version: "2.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1430,18 +1430,18 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "8582d7f6fe14d2652b4c45c9b6c14c0b678c2af2d083a11b604caeba51930d79"
+      sha256: "0aedad096a85b49df2e4725fa32118f9fa580f3b14af7a2d2221896a02cd5656"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.16"
+    version: "6.3.17"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1598,10 +1598,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "51d50168ab267d344b975b15390426b1243600d436770d3f13de67e55b05ec16"
+      sha256: "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.5.1"
   xdg_directories:
     dependency: transitive
     description:


### PR DESCRIPTION
issue: https://github.com/daodao97/chatmcp/issues/180

- Introduced ClaudeCodeClient for interacting with the Claude Code SDK CLI.
- Updated LLMProvider enum to include 'claudeCode'.
- Enhanced LLMFactory to create instances of ClaudeCodeClient.
- Added default settings for Claude Code in settings_provider.dart, including model configurations and documentation link.
