### PR TITLE
build(linux): add popos 22.04 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,13 +74,38 @@ jobs:
         if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build libgtk-3-dev locate libsqlite3-dev fuse libfuse2
+          sudo apt-get install -y ninja-build libgtk-3-dev locate libsqlite3-dev fuse libfuse2 libstdc++-12-dev patchelf
           sudo updatedb
           wget -O appimagetool "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
           chmod +x appimagetool
           sudo mv appimagetool /usr/local/bin/
           fastforge release --name=linux
           fastforge release --name=android
+
+      - name: Verify AppImage GLIBC compatibility (Pop!_OS 22.04)
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          set -e
+          shopt -s nullglob
+          found=0
+          for f in dist/**/*AppImage dist/*.AppImage; do
+            echo "Checking $f"
+            chmod +x "$f"
+            "$f" --appimage-extract >/dev/null 2>&1 || true
+            if [ -d squashfs-root/usr/lib ]; then
+              if strings squashfs-root/usr/lib/libstdc++.so.6 | grep -E 'GLIBC_2\.(36|37|38|39)' -q; then
+                echo "❌ $f contains libstdc++ requiring newer GLIBC" >&2
+                exit 1
+              fi
+            fi
+            rm -rf squashfs-root
+            found=1
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "No AppImage files found under dist/. Skipping check."
+          else
+            echo "✅ AppImage libstdc++ is compatible with GLIBC 2.35 hosts."
+          fi
 
       - name: Setup Node.js for macOS
         if: matrix.os == 'macos-latest'

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Cross-platform `Macos | Windows | Linux | iOS | Android | Web` AI Chat Client
 | [Release](https://github.com/daodao97/chatmcp/releases) | [Release](https://github.com/daodao97/chatmcp/releases) | [Release](https://github.com/daodao97/chatmcp/releases) ¹ | [TestFlight](https://testflight.apple.com/join/dCXksFJV) | [Release](https://github.com/daodao97/chatmcp/releases) | [GitHub Pages](https://daodao97.github.io/chatmcp) ² |
 
 ¹ **Linux Notes:** 
-- Install required dependencies: `sudo apt install libsqlite3-0 libsqlite3-dev` on Debian/Ubuntu and derivatives
+- See Linux requirements below for AppImage/DEB runtime dependencies on Ubuntu 22.04 and 24.04
 - Improved Experience: Latest versions include better dark theme support, unified data storage following [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), and optimized UI layout for Linux desktop environments is planned
 - Tested on major distributions: Ubuntu, Fedora, Arch Linux, openSUSE
 
@@ -73,6 +73,31 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 sudo apt update
 sudo apt install nodejs npm
 ```
+
+### Linux Requirements (Ubuntu 22.04 and 24.04)
+
+For running ChatMCP AppImage/DEB on Ubuntu and derivatives, install the following runtime packages:
+
+- AppImage (FUSE): `libfuse2`
+- GTK 3: `libgtk-3-0`
+- Graphics/EGL:
+  - Ubuntu 22.04: `libegl1-mesa`, `libgles2`, `libgl1-mesa-dri`, `libglx-mesa0`
+  - Ubuntu 24.04: `libegl1`, `libgles2`, `libgl1-mesa-dri`, `libglx-mesa0`
+- X11 utilities and SQLite: `libx11-6`, `xdg-utils`, `libsqlite3-0`
+
+Install commands:
+
+- Ubuntu 22.04:
+```bash
+sudo apt install -y libfuse2 libgtk-3-0 libegl1-mesa libgles2 libgl1-mesa-dri libglx-mesa0 libx11-6 xdg-utils libsqlite3-0
+```
+
+- Ubuntu 24.04:
+```bash
+sudo apt install -y libfuse2 libgtk-3-0 libegl1 libgles2 libgl1-mesa-dri libglx-mesa0 libx11-6 xdg-utils libsqlite3-0
+```
+
+Optional (recommended): `mesa-vulkan-drivers`, `mesa-utils` (for diagnostics like glxinfo)
 
 1. Configure Your LLM API Key and Endpoint in `Setting` Page
 2. Install MCP Server from `MCP Server` Page

--- a/README_TR.md
+++ b/README_TR.md
@@ -14,12 +14,7 @@ Platformlar Arası <code>MacOS | Windows | Linux | iOS | Android | Web</code> Ya
 |-------------------------------------------------------|-------------------------------------------------------|---------------------------------------------------------|----------------------------------------------------------|-------------------------------------------------------|--------------------------------------------------------|
 | [İndir](https://github.com/daodao97/chatmcp/releases) | [İndir](https://github.com/daodao97/chatmcp/releases) | [İndir](https://github.com/daodao97/chatmcp/releases) ¹ | [TestFlight](https://testflight.apple.com/join/dCXksFJV) | [İndir](https://github.com/daodao97/chatmcp/releases) | [GitHub Pages](https://daodao97.github.io/chatmcp) ² |
 
-¹ Not: Linux'ta, `sqflite_common_ffi` paketinin çalışması için `libsqlite3-0` ve `libsqlite3-dev` kütüphanelerini kurmanız
-gerekir: https://pub.dev/packages/sqflite_common_ffi
-
-```bash
-sudo apt-get install libsqlite3-0 libsqlite3-dev
-```
+¹ Not: Linux gereksinimleri aşağıdadır (Ubuntu 22.04 ve 24.04)
 
 ² Not: Web sürümü tamamen tarayıcınızda çalışır ve sohbet geçmişi ile ayarlar için yerel depolama kullanır.
 
@@ -61,6 +56,31 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 sudo apt update
 sudo apt install nodejs npm
 ```
+
+### Linux Gereksinimleri (Ubuntu 22.04 ve 24.04)
+
+ChatMCP AppImage/DEB çalıştırmak için aşağıdaki paketlerin kurulu olması gerekir:
+
+- AppImage (FUSE): `libfuse2`
+- GTK 3: `libgtk-3-0`
+- Grafik/EGL:
+  - Ubuntu 22.04: `libegl1-mesa`, `libgles2`, `libgl1-mesa-dri`, `libglx-mesa0`
+  - Ubuntu 24.04: `libegl1`, `libgles2`, `libgl1-mesa-dri`, `libglx-mesa0`
+- X11 yardımcıları ve SQLite: `libx11-6`, `xdg-utils`, `libsqlite3-0`
+
+Kurulum komutları:
+
+- Ubuntu 22.04:
+```bash
+sudo apt install -y libfuse2 libgtk-3-0 libegl1-mesa libgles2 libgl1-mesa-dri libglx-mesa0 libx11-6 xdg-utils libsqlite3-0
+```
+
+- Ubuntu 24.04:
+```bash
+sudo apt install -y libfuse2 libgtk-3-0 libegl1 libgles2 libgl1-mesa-dri libglx-mesa0 libx11-6 xdg-utils libsqlite3-0
+```
+
+Opsiyonel (önerilir): `mesa-vulkan-drivers`, `mesa-utils` (glxinfo gibi teşhis araçları)
 
 1. Ayarlar sayfasında LLM API Anahtarınızı ve Uç Noktanızı (Endpoint) yapılandırın.
 2. MCP Sunucusu sayfasından bir MCP sunucusu kurun.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -14,16 +14,12 @@
 |-----------------------------------------------------------|---------------------------------------------------------------|---------------------------------------------------------------|
 | macOS                                                     | [Release](https://github.com/daodao97/chatmcp/releases)       |                                                               |
 | Windows                                                   | [Release](https://github.com/daodao97/chatmcp/releases)       |                                                               |
-| Linux                                                     | [Release](https://github.com/daodao97/chatmcp/releases)       | 需要安装 `libsqlite3-0` 和 `libsqlite3-dev` ¹                |
+| Linux                                                     | [Release](https://github.com/daodao97/chatmcp/releases)       | 请参见下方“Linux 运行环境需求” ¹                              |
 | iOS                                                       | [TestFlight](https://testflight.apple.com/join/dCXksFJV)      |                                                               |
 | Android                                                   | [Release](https://github.com/daodao97/chatmcp/releases)       |                                                               |
 | Web                                                       | [GitHub Pages](https://daodao97.github.io/chatmcp)           | 完全在浏览器中运行，使用本地存储保存聊天记录和设置 ²            |
 
-¹ 注意：在 Linux 系统上，您需要安装 `libsqlite3-0` 和 `libsqlite3-dev`，因为依赖包需要这些库：
-
-```bash
-sudo apt-get install libsqlite3-0 libsqlite3-dev
-```
+¹ 提示：请参见下方“Linux 运行环境需求（Ubuntu 22.04 与 24.04）”。
 
 ² 注意：Web 版本完全在您的浏览器中运行，使用本地存储保存聊天记录和设置。
 
@@ -60,6 +56,31 @@ brew install uv
 # npx
 brew install node 
 ```
+
+### Linux 运行环境需求（Ubuntu 22.04 与 24.04）
+
+在 Ubuntu 及其衍生发行版上运行 ChatMCP 的 AppImage/DEB，请确保安装以下运行时依赖：
+
+- AppImage（FUSE）：`libfuse2`
+- GTK 3：`libgtk-3-0`
+- 图形/EGL：
+  - Ubuntu 22.04：`libegl1-mesa`、`libgles2`、`libgl1-mesa-dri`、`libglx-mesa0`
+  - Ubuntu 24.04：`libegl1`、`libgles2`、`libgl1-mesa-dri`、`libglx-mesa0`
+- 其他：`libx11-6`、`xdg-utils`、`libsqlite3-0`
+
+安装命令示例：
+
+- Ubuntu 22.04：
+```bash
+sudo apt install -y libfuse2 libgtk-3-0 libegl1-mesa libgles2 libgl1-mesa-dri libglx-mesa0 libx11-6 xdg-utils libsqlite3-0
+```
+
+- Ubuntu 24.04：
+```bash
+sudo apt install -y libfuse2 libgtk-3-0 libegl1 libgles2 libgl1-mesa-dri libglx-mesa0 libx11-6 xdg-utils libsqlite3-0
+```
+
+可选（推荐）：`mesa-vulkan-drivers`、`mesa-utils`（如 glxinfo 等诊断工具）
 
 1. 在"设置"页面配置您的 LLM API 密钥和端点
 2. 从"MCP 服务器"页面安装 MCP 服务器

--- a/linux/packaging/appimage/make_config.yaml
+++ b/linux/packaging/appimage/make_config.yaml
@@ -24,3 +24,16 @@ startup_notify: true
 include:
   - libsqlite3.so.0
   - libsqlite3.so
+
+# Avoid bundling core system libraries that must be provided by the host.
+# Bundling these can introduce newer GLIBC symbol requirements (e.g. 2.36/2.38)
+# and break compatibility with Pop!_OS 22.04 (glibc 2.35).
+exclude:
+  - libc.so.6
+  - libpthread.so.0
+  - libdl.so.2
+  - libm.so.6
+  - libresolv.so.2
+  - librt.so.1
+  - libstdc++.so.6
+  - libgcc_s.so.1

--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -14,7 +14,7 @@ installed_size: 20000
 dependencies:
   - libgtk-3-0
   - libsqlite3-0
-  - libsqlite3-dev
+  # Runtime should not depend on -dev packages
 
 essential: false
 


### PR DESCRIPTION
### Summary
* Produce AppImage compatible with Ubuntu 22.04 (glibc 2.35) and Ubuntu 24.04.
* Prevent bundling core system libs that force newer GLIBC.
* Add CI guard to fail builds if AppImage embeds libstdc++ requiring GLIBC ≥ 2.36.
* Document Linux runtime packages (EN/TR/ZH).

### Context/Motivation
* Users on Pop!OS 22.04 were unable to run AppImage due to embedded usr/lib/libstdc++.so.6 requiring GLIBC_2.36/2.38.
* AppImage cannot safely ship glibc; must rely on host glibc and avoid shipping newer libstdc++.
* Ensure predictable releases across Ubuntu 22.04/24.04.

### Changes
* linux/packaging/appimage/make_config.yaml
* Add exclude list to avoid bundling: libc.so.6, libpthread.so.0, libdl.so.2, libm.so.6, libresolv.so.2, librt.so.1, libstdc++.so.6, libgcc_s.so.1.
* Keep sqlite libs included.
* linux/packaging/deb/make_config.yaml
Remove -dev runtime dependency (keep libsqlite3-0 only).
* .github/workflows/build.yml
* On ubuntu-22.04 build: install libstdc++-12-dev, patchelf.
* After packaging, extract AppImage and check for GLIBC_2.36/2.38 symbols in usr/lib/libstdc++.so.6; fail if found.

### Docs
* README.md: Add “Linux Requirements (Ubuntu 22.04 and 24.04)”.
* README_TR.md: Add “Linux Gereksinimleri (Ubuntu 22.04 ve 24.04)”.
* README_ZH.md: Add “Linux 运行环境需求（Ubuntu 22.04 与 24.04）”.

### Testing
* Local: Built AppImage on Ubuntu 22.04 environment; verified no embedded libstdc++ with GLIBC_2.36/2.38 symbols.
* Runtime: Manually tested AppImage on Pop!OS 22.04 and Linux Mint — launches successfully.
* CI: New symbol gate will fail builds if incompatible libstdc++ is bundled.

### Backward Compatibility
* AppImage now targets host glibc and should run on Ubuntu 22.04 (glibc 2.35) and 24.04.
* DEB dependency cleanup does not remove required runtime libraries.

### Operational Notes
* If users hit X11/GLX issues on certain drivers, suggest trying Wayland or forcing Mesa/software path as documented.
* Consider adding an optional CI step to assert presence of AppRun in extracted AppImage if needed.

### Checklist
- [x] AppImage excludes core system libs
- [x] CI symbol gate for GLIBC 2.36/2.38
- [x] Docs updated in EN/TR/ZH
- [x] Local validation on **22.04**-based systems
- [x] Local validation on **24.04**-based system 